### PR TITLE
feat:Implemented logic to count projects for a user in /user/count/:u…

### DIFF
--- a/Backend/routers/candidates.js
+++ b/Backend/routers/candidates.js
@@ -97,6 +97,9 @@ router.get('/user/count/:userId', async (req, res) => {
     if (!mongoose.isValidObjectId(userId)) {
         return res.status(400).json({ success: false, message: 'Invalid User ID format' });
     }
+
+    // Count projects associated with the user
+    const projectCount = await Project.countDocuments({ user: userId });
 });
 
 // Update candidate details


### PR DESCRIPTION
…serId

Used Project.countDocuments() to count the number of projects associated with the userId.

1. Stored the result in a projectCount variable.